### PR TITLE
Add Jan 30, Feb 6 (2019) status meetings

### DIFF
--- a/status_meetings/status-2019-01-30.md
+++ b/status_meetings/status-2019-01-30.md
@@ -1,0 +1,52 @@
+---
+tags: NumPy, BIDS
+---
+
+# 2019-1-30 BIDS/NumPy Development Meeting
+
+
+- Join via Zoom at [https://berkeley.zoom.us/j/400054438](https://berkeley.zoom.us/j/400054438), or dial-in through a [local phone number](https://zoom.us/u/adQDmEc1wI).
+- [Trello workboard](https://trello.com/b/Azg4fYZH/numpy-at-bids)
+- [Previous meetings](https://github.com/BIDS-numpy/docs/tree/master/status_meetings)
+- [NumPy at BIDS Calendar](https://calendar.google.com/calendar?cid=YmVya2VsZXkuZWR1X2lla2dwaWdtMjMyamJobGRzZmIyYzJqODFjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+
+**Present:** Tyler, Matti, Sasha (Intel), Stefan, Chuck, Hameer (Quansight)
+
+## Follow-up from last meeting/discussions
+- [timsort sort](https://github.com/numpy/numpy/pull/12418/)
+    - Should add to ASV benchmarks [Hameer will take this on] -- see `setup_cache` for saving time on setups maybe: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown-functions
+    - Need to extend the benchmark suite for the explicit sorting names
+  - Conclusion: in it goes!
+
+- Discuss web hosting situation with NumPy steering council to verify the decision to push github pages [Stéfan]
+  - The best way to do this would be to automate circleci for (maintainence-1.16.x, tag) builds to upload documents appropriately. Is it possible? I (mattip) couldn't work out how to run circleci locally.
+- [sphinx warnings](https://circleci.com/gh/numpy/numpy/5751?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) for subclasses of ndarray while collecting autosummary (about half way down the `build devdocs` tab): numpydocs had no reaction to the [issue](https://github.com/numpy/numpydoc/issues/199)  (mattip)
+- We still seeing issues with sporadic i386 failures, bisected to the addition of pocketfft and c99 (could we explore bumping the gcc compiler toolchain version for our wheel builds / openblas as well?); need caution for gfortran version I think? (chuck)
+  - we could try opening a PR to bump this for openblas builds and see what goes wrong I suppose; I think Mac is a little awkard if you try to bump the toolchain; remember that other OS projects use MacPython system too, so check with them probably?
+  - we're only pinning Windows for 32-bit for dev testing; gcc 8.x mingw toolchain seems ok for 64-bit Win, and even allows DLL OpenBLAS version detection (though can't build NumPy off the DLL just yet)
+  - Can we reproduce in a stand-alone docker (so far, no)? Perhaps then there is a way to check the floating-point registers that control the accuracy???
+      - After reproduction: Change compiler, BLAS, roll back pocketfft
+
+## Community Suggested Topics
+
+- Tutorial on wrapping C for SciPy? (mattip)~
+- Stefan wants to do intermediate to advanced NumPy tutorial at SciPy (we haven't had such a tutorial there since, maybe, 2009?); we can divide the workload of writing the material and presenting
+- Problem compiling on windows with python 2.7 (Oleksandr): somehow concatenating the args together to a str makes it work properly. Issue is on the way.
+
+
+## Work status
+
+Matti:
+- Workarounds for 1.16 problems.
+  - Try to get debian to fix their pip  (Julian Taylor?)
+- Dtype work has stalled, waiting for reactions to the NEP (Martin, Eric?).
+
+Tyler:
+- working on SciPy manuscript -- see [checklist](https://github.com/scipy/scipy-articles/issues/65) [28/73]
+  - now letting others make changes as they see fit to reduce likelihood of making PRs without consensus for change
+- OpenBLAS version detection via DLL looking a little better on Windows
+  - Consider taking the scripts used to build the openblas libraries out into a submodule
+
+---
+
+Please remember to archive this file and commit it to github.com/bids-numpy/docs

--- a/status_meetings/status-2019-02-06.md
+++ b/status_meetings/status-2019-02-06.md
@@ -1,0 +1,50 @@
+---
+tags: NumPy, BIDS
+---
+
+# 2019-2-06 BIDS/NumPy Development Meeting
+
+
+- Join via Zoom at [https://berkeley.zoom.us/j/400054438](https://berkeley.zoom.us/j/400054438), or dial-in through a [local phone number](https://zoom.us/u/adQDmEc1wI).
+- [Trello workboard](https://trello.com/b/Azg4fYZH/numpy-at-bids)
+- [Previous meetings](https://github.com/BIDS-numpy/docs/tree/master/status_meetings)
+- [NumPy at BIDS Calendar](https://calendar.google.com/calendar?cid=YmVya2VsZXkuZWR1X2lla2dwaWdtMjMyamJobGRzZmIyYzJqODFjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+
+**Present:** Stefan, Matti, Hameer, Tyler
+
+## Follow-up from last meeting/discussions
+- timsort and related sorting enhancements?
+    - Matti merged timsort, but some caution needed with backwards-compatibility. Proposed action: Need to find a case where this actually matters before dumping too much energy in to it!
+    - [NumPy ABI forward compatibility](https://github.com/numpy/numpy/issues/5888)
+- SciPy 2019 [Conference Submissions](https://hackmd.io/bzbzioNFRIWfEdGCp3pAqQ) -- Deadline extended to Feb. 15th.
+  - detailed description section for tutorials can be a fair bit of work
+  - Tyler may consider an updated "Mastering `scipy.spatial`" tutorial, but maybe not! These things are really time consuming to do well.
+
+## Community Suggested Topics
+
+- 12889 PR -- allow_pickle changes for security -- Intel obligation to fix (Sasha) -- savez, savez compressed are causing issues though?
+  - Intel is likely to leave savez, savez compressed unchanged; 1.16.1 will have behavior difference b/w Intel & release (policies require CVE fix before install), but 1.16.2 should converge back again
+
+## Work status
+
+Matti (at a PyPy sprint all week, so this is really only Thurs, Fri):
+- Helping with the 1.16.1 release issues (pickling ndarrays, removing flaky test, help debugging azure pipeline failures)
+- Try to unstick dtype progress by writing another [dtype document](https://hackmd.io/ok21UoAQQmOtSVk6keaJhw?both#) thinking maybe github comments is no the forum to manage a discussion. But that didn't work either. Maybe we need to do a "dtype summit" over a weekend to get some of the higher level details discussed to progress could be made? Could it be virtual? I could come to the west coast for that?
+  - TODO: Get all the documents together in one place, post it to the dev mailing list with a call to get reactions
+
+Tyler:
+- SciPy `1.2.1` -- I've delayed on this too long
+- SciPy manuscript moving slowly as usual (55 % checklist items complete as of this morning; some may be eliminated by consensus)
+- lots of stuck PRs / issues--generally because they're challenging--a few examples:
+  - `int64 //= uint64` [no longer raises](https://github.com/numpy/numpy/issues/12927) `TypeError` in NumPy `1.16.1`
+    - related to recent `np.datetime64` floordiv enhancements
+    - [PR now open](https://github.com/numpy/numpy/pull/12940)
+  - ctypes / Windows DLL handling for [OpenBLAS version detection](https://github.com/numpy/numpy/pull/12790) remains a challenging / very time consuming endeavor 
+  - SciPy ConvexHull issues on older Mac / Xcode [reported](https://github.com/scipy/scipy/issues/9751) from scikit-image team
+    - `libc++` header issues or something else? -- need to uncouple Mac OS version switching from Xcode version switching in the bug reports to start with; not fun to debug
+- there's a really cool [`ConvexHull` facet visibility enhancement PR open](https://github.com/scipy/scipy/pull/9721) that I'm reviewing
+- I should start splitting up some of my SciPy computational geometry work into smaller PRs, maybe, but question of priorities
+  
+---
+
+Please remember to archive this file and commit it to github.com/bids-numpy/docs


### PR DESCRIPTION
Add the meeting minutes from our last two Wednesday sessions, so they don't get lost in the HackMD abyss.