### PR TITLE
Add March 6/ 2019 meeting minutes

### DIFF
--- a/status_meetings/status-2019-03-06.md
+++ b/status_meetings/status-2019-03-06.md
@@ -53,7 +53,3 @@ Tyler:
   - a variety of other efforts in NumPy & SciPy, including reviewing PRs for SciPy paper
   - Connected with Carl Kleffner about SciPy Fortran compiler
 - [OpenBLAS version detection PR](https://github.com/numpy/numpy/pull/12790) by Tyler is working, needs review. Downside currently is that it generates an extra DLL, is this acceptable?
- 
----
-
-Please remember to archive this file and commit it to github.com/bids-numpy/docs

--- a/status_meetings/status-2019-03-06.md
+++ b/status_meetings/status-2019-03-06.md
@@ -1,0 +1,59 @@
+---
+tags: NumPy, BIDS
+---
+
+# 2019-3-06 BIDS/NumPy Development Meeting
+
+- Join via Zoom at [https://berkeley.zoom.us/j/400054438](https://berkeley.zoom.us/j/400054438), or dial-in through a [local phone number](https://zoom.us/u/adQDmEc1wI).
+- [Trello workboard](https://trello.com/b/Azg4fYZH/numpy-at-bids)
+- [Previous meetings](https://github.com/BIDS-numpy/docs/tree/master/status_meetings)
+- [NumPy at BIDS Calendar](https://calendar.google.com/calendar?cid=YmVya2VsZXkuZWR1X2lla2dwaWdtMjMyamJobGRzZmIyYzJqODFjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+
+**Present:** Hameer, Ralf, Matti, Tyler, Stéfan, Oleksandr, ?Guest?
+
+## Follow-up from last meeting/discussions
+
+- sorting progress?
+  - Timsort currently appears to be superior--is `radixsort` still worth adding? Timsort replaces mergesort, but radixsort would be more intrusive to ABI. Conclusion: let's just keep the PR for now, could be useful in future!
+- TODO: Document contact person and how we access the gcc build farm (and other similar resources).
+  - Matti, Ralf and Tyler have access to the [build farm](https://cfarm.tetaneutral.net/machines/list/) via ssh. Matti is looking at the [unpackbits pr](https://github.com/numpy/numpy/pull/12962) on a MIPS (little-endian) machine. Ralf has started looking into AIX build issues.
+  - TODO: give core devs access to a private repo with debug machine access info (gcc farm, etc.)
+      - Cannot host this on GitHub, they only allow 3 private collaborators
+      - This now lives at https://gitlab.com/numpy/logistics.git
+- Intel distribution of NumPy---have they started looking at issues to "poach?": https://github.com/IntelPython/numpy
+  - should we publish that repo somewhere? In an issue template perhaps (mattip)
+
+## Community Suggested Topics
+
+- Outreachy: NumPy is now a mentoring organization. Deadline for project definition and adding mentors: March 12th. Sebastian + Matti have agreed to mentor.
+- Hameer:
+    - Add mixins for easier duck-typing of arrays.
+        - PR: https://github.com/numpy/numpy/pull/10460
+        - there's an open issue here that requires more discussion: https://github.com/numpy/numpy/issues/10446
+    - Would be nice to turn `np.where` into a ufunc, but I don't know how yet.
+        - https://github.com/numpy/numpy/issues/8994
+        - The ufuncs are generated via a python script in `core/code_generators/generate_umath.py`, which spits out c code. Usually the loops are written in `core/umath/loops*` or so, as a set of `*.c.src` files. To add one, 
+
+## Work status
+
+Matti:
+  - Turning on `-n` for sphinx-build revealed over 1000 bad references in the documentation. Example: the [SeeAlso](http://www.numpy.org/devdocs/reference/generated/numpy.polynomial.chebyshev.chebroots.html) section. 
+    - numpydoc fix may be needed re: backtick usage (currently, `arg` is not interpreted, leading to a "missing reference" in Sphinx)
+    - is parameter and return value formatting documented in numpydocs? It should parse and mark these for special formatting, but other things (See Also and others) must be references.
+  - Unfortunately I was sick for most of the week with a bad throat/cold, and could not really function. A bit better today.
+
+Tyler:
+  - trying to push [Eric's `np.clip() ufunc` PR](https://github.com/numpy/numpy/pull/12519) forward a bit by:
+    - adding tests
+    - addressing reviewer comments where possible
+  - some `datetime64` PRs remain challenging:
+    - [changes in `int->m8` casting behavior](https://github.com/numpy/numpy/pull/13061)
+    - [`datetime64` span chokes/ silent wrapping](https://github.com/numpy/numpy/pull/11873)
+  - [draft of `nansum` using `_nan_mask()`](https://github.com/numpy/numpy/pull/12801) has been a little underwhelming so far
+  - a variety of other efforts in NumPy & SciPy, including reviewing PRs for SciPy paper
+  - Connected with Carl Kleffner about SciPy Fortran compiler
+- [OpenBLAS version detection PR](https://github.com/numpy/numpy/pull/12790) by Tyler is working, needs review. Downside currently is that it generates an extra DLL, is this acceptable?
+ 
+---
+
+Please remember to archive this file and commit it to github.com/bids-numpy/docs


### PR DESCRIPTION
Add the meeting minutes from BIDS / NumPy community call on March 6/ 2019